### PR TITLE
Update distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN case $TARGETPLATFORM in \
 
     cp target/$TARGET/release/ddns-cloudflare .
 
-FROM gcr.io/distroless/cc:latest@sha256:3603adbdee2906dc3b7a18d7c0424a40633231c61dcd82196ae15de1282a5822
+FROM gcr.io/distroless/cc-debian12:latest@sha256:f44927808110f578fba42bf36eb68a5ecbb268b94543eb9725380ec51e9a39ed
 
 COPY --from=builder /app/ddns-cloudflare /
 


### PR DESCRIPTION
Versions after https://github.com/pkoenig10/ddns-cloudflare/pull/122 produce the following error:

```
/ddns-cloudflare: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /ddns-cloudflare)
/ddns-cloudflare: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /ddns-cloudflare)
/ddns-cloudflare: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /ddns-cloudflare)
```

The `rust` image upgraded to Debian 12 in https://github.com/rust-lang/docker-rust/commit/3c948e6255412b0b72ef4c4b1a4cee448bed4c29, but `distroless/cc` is still using Debian 11.